### PR TITLE
Simplify deployment process

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ volumes:
 ```
 
 5. Create `nginx/htpasswd` to provide Basic-Authentification for Nginx.
-Change `dnf` to your package manager and `anyusername` to your needs.
 In end you will be prompted to enter password to console.
 ```
-dnf install -y httpd-tools
-htpasswd -c nginx/htpasswd anyusername
+docker-compose run nginx htpasswd -c /etc/nginx-secrets/htpasswd anyusername
 ```
+
+You will be prompted for password.
 
 6. Generate & put your SSL keypair `kibana.crt` and `kibana.key` to `nginx/ssl` folder.
 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,23 @@ docker-compose run nginx htpasswd -c /etc/nginx-secrets/htpasswd anyusername
 
 You will be prompted for password.
 
-6. Generate & put your SSL keypair `kibana.crt` and `kibana.key` to `nginx/ssl` folder.
+6. Generate SSL certificates
 
-There are to many posible solutuins like [Let's Encrypt](https://letsencrypt.org/docs/client-options/), private PKI or [self-hosted](https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-nginx-in-ubuntu-16-04) certificates.
+The following example leverages the Cloudflare API. But you can
+similary use any of the options provided by acme.sh. But if you do,
+don't forget to create a pull request with the verified steps :).
 
-It all up to you what to use. Note: for Let's Encrypt you need modify nginx configs to support it. You can use local ACME or modify docker-compose image. 
+Update `docker-compose.yml` with your Cloudflare credentials, and then simply run:
+
+```
+docker-compose run acme.sh --issue -d parsedmarc.your.domain --dns dns_cf
+ocker-compose run acme.sh --install-cert -d parsedmarc.your.domain --cert-file /installed_certs/kibana.crt --key-file /installed_certs/kibana.key
+```
+
+From now on, acme.sh container will take care of certifcates
+renewal. The nginx would not get automatically restarted, but it will
+reload certificates once a week by means of a cron job.
+
 
 7. Create needed folders and configure permissions.
 ```

--- a/README.md
+++ b/README.md
@@ -55,12 +55,15 @@ user = parsedmarc@example.com
 password = somepassword
 ```
 
-4. Enable IP geolocation by installing [GeoIP Update software](https://github.com/maxmind/geoipupdate). And edit `docker-compose.yml` to enable access to the MaxMind databases on your host system.
-```
-volumes:
-  - ./parsedmarc/parsedmarc.ini:/etc/parsedmarc.ini:z
-  - /path/to/GeoIP:/usr/share/GeoIP
-```
+4. Geolocation data
+
+Create an account and generate a licence key at
+[maxmind](https://www.maxmind.com/en/accounts/current/license-key). And
+update GEOIPUPDATE_ACCOUNT_ID and GEOIPUPDATE_LICENSE_KEY in the
+`docker-compose`
+
+For more information refer to [GeoIP Update
+software](https://github.com/maxmind/geoipupdate) github page
 
 5. Create `nginx/htpasswd` to provide Basic-Authentification for Nginx.
 In end you will be prompted to enter password to console.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.4'
+version: '3.4'
 
 services:
   parsedmarc:
@@ -31,7 +31,7 @@ services:
         soft: -1
         hard: -1
     volumes:
-      - ./elasticsearch/data/:/usr/share/elasticsearch/data/:z
+      - elasticsearch_data:/usr/share/elasticsearch/data/
     restart: "unless-stopped"
     networks:
       - parsedmarc-network
@@ -77,3 +77,5 @@ services:
 networks:
     parsedmarc-network:
       driver: bridge
+volumes:
+  elasticsearch_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,14 +71,29 @@ services:
       - "443:443"
     volumes:
       - ./nginx/conf.d/:/etc/nginx/conf.d/:z
-      - ./nginx/ssl/:/etc/nginx/ssl/:z
+      - acme_certs:/etc/nginx/ssl/
       - nginx_secrets:/etc/nginx-secrets
     networks:
       - parsedmarc-network
 
+  acme.sh:
+    image: neilpang/acme.sh
+    container_name: acme.sh
+    command: daemon
+    volumes:
+      - acmeout:/acme.sh
+      - acme_certs:/installed_certs
+    environment:
+
+      # CloudFlare
+      - CF_Token=
+      - CF_Account_ID=
+      - CF_Zone_ID=
 networks:
     parsedmarc-network:
       driver: bridge
 volumes:
+  acmeout:
   elasticsearch_data:
+  acme_certs:
   nginx_secrets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,27 @@ services:
     tty: true
     volumes:
       - ./parsedmarc/parsedmarc.ini:/etc/parsedmarc.ini:z
-      #- /path/to/GeoIP:/usr/share/GeoIP
+      - geoipupdate_data:/usr/share/GeoIP
     restart: unless-stopped
     networks:
       - parsedmarc-network
     depends_on:
       elasticsearch:
         condition: service_healthy
+
+  geoipupdate:
+    container_name: geoipupdate
+    image: maxmindinc/geoipupdate
+    restart: unless-stopped
+    environment:
+      - GEOIPUPDATE_ACCOUNT_ID=
+      - GEOIPUPDATE_LICENSE_KEY=
+      - 'GEOIPUPDATE_EDITION_IDS=GeoLite2-ASN GeoLite2-City GeoLite2-Country'
+      - GEOIPUPDATE_FREQUENCY=72
+    networks:
+      - geoipupdate
+    volumes:
+      - geoipupdate_data:/usr/share/GeoIP
 
   elasticsearch:
     container_name: "elasticsearch"
@@ -92,8 +106,11 @@ services:
 networks:
     parsedmarc-network:
       driver: bridge
+    geoipupdate:
+
 volumes:
   acmeout:
   elasticsearch_data:
+  geoipupdate_data:
   acme_certs:
   nginx_secrets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,9 @@ services:
 
   nginx:
     container_name: "nginx"
-    image: nginx:alpine
+    build:
+      context: .
+      dockerfile: nginx/Dockerfile
     restart: unless-stopped
     tty: true
     ports:
@@ -70,7 +72,7 @@ services:
     volumes:
       - ./nginx/conf.d/:/etc/nginx/conf.d/:z
       - ./nginx/ssl/:/etc/nginx/ssl/:z
-      - ./nginx/htpasswd:/etc/nginx/htpasswd:z
+      - nginx_secrets:/etc/nginx-secrets
     networks:
       - parsedmarc-network
 
@@ -79,3 +81,4 @@ networks:
       driver: bridge
 volumes:
   elasticsearch_data:
+  nginx_secrets:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,4 @@
+from nginx:alpine
+
+RUN apk add --no-cache --virtual .checksum-deps \
+    apache2-utils

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,5 @@
 from nginx:alpine
 
 RUN apk add --no-cache --virtual .checksum-deps \
-    apache2-utils
+    apache2-utils && \
+   echo "0 0 * * 0 nginx -s reload" | crontab -

--- a/nginx/conf.d/kibana.conf
+++ b/nginx/conf.d/kibana.conf
@@ -16,7 +16,7 @@ server {
     add_header X-Frame-Options SAMEORIGIN;
     add_header X-Content-Type-Options nosniff;
     auth_basic "Login required";
-    auth_basic_user_file /etc/nginx/htpasswd;
+    auth_basic_user_file /etc/nginx-secrets/htpasswd;
 
     location / {
         proxy_pass http://kibana:5601;

--- a/parsedmarc/parsedmarc.ini
+++ b/parsedmarc/parsedmarc.ini
@@ -6,6 +6,8 @@ save_forensic = True
 host = imap.example.com
 user = parsedmarc@example.com
 password = somepassword
+
+[mailbox]
 watch = True
 
 [elasticsearch]


### PR DESCRIPTION
My 2cents to simplify building service. Includes
- acme.sh certificates generation
- htpass done within containers
- geoip service as a part of docker-compose