### PR TITLE
Prevent pip from using a cache dir during build

### DIFF
--- a/parsedmarc/Dockerfile
+++ b/parsedmarc/Dockerfile
@@ -2,7 +2,7 @@ FROM pypy:latest
 
 RUN apt-get update \
     && apt-get install -y libxml2-dev libxslt-dev python-dev \
-    && pip install parsedmarc \
+    && pip install --no-cache-dir parsedmarc \
     && rm -rf /root/.cache/ \
     && rm -rf /var/lib/{apt,dpkg}/
 


### PR DESCRIPTION
- additionally to "rm" commands to ensure that no cache is kept