### PR TITLE
Remove portforwarding of Kibana

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,6 @@ services:
       - server.host="0"
       - elasticsearch.hosts=http://elasticsearch:9200
       - xpack.monitoring.ui.container.elasticsearch.enabled=true
-    ports:
-      - "5601:5601"
     restart: unless-stopped
     networks:
       - parsedmarc-network


### PR DESCRIPTION
- not required because nginx does make Kibana accessible
- nginx can access Kibana without the portforwarding successfully
- fixes #12 