### PR TITLE
Fix kibana environment configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     image: docker.elastic.co/kibana/kibana:7.17.0
     environment:
       SERVER_NAME: parsedmarc
-      SERVER_HOST: "0"
+      SERVER_HOST: "0.0.0.0"
       ELASTICSEARCH_HOSTS: http://elasticsearch:9200
       XPACK_MONITORING_UI_CONTAINER_ELASTICSEARCH_ENABLED: "true"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,10 +46,10 @@ services:
     container_name: "kibana"
     image: docker.elastic.co/kibana/kibana:7.17.0
     environment:
-      - server.name=parsedmarc
-      - server.host="0"
-      - elasticsearch.hosts=http://elasticsearch:9200
-      - xpack.monitoring.ui.container.elasticsearch.enabled=true
+      SERVER_NAME: parsedmarc
+      SERVER_HOST: "0"
+      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+      XPACK_MONITORING_UI_CONTAINER_ELASTICSEARCH_ENABLED: "true"
     ports:
       - "5601:5601"
     restart: unless-stopped


### PR DESCRIPTION
When configuring Kibana with environment variables, they need to have the format `SERVER_HOST` and not `server.host`. See official docs: https://www.elastic.co/guide/en/kibana/current/docker.html

Also server host needed to be 0.0.0.0 because otherwise Kibana does not start because of '"host" must be a string'.

Verified on my deployment that configuration is now working.