### PR TITLE
Improve Docker deployment: add MS Graph token refresh, hardened runtime, and OpenSearch/ELK setups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Zewnętrzna sieć docker, gdzie działa stack Elasticsearch/Kibana
+ELASTIC_NETWORK=elasticsearch_elastic
+
+# Opcjonalnie: msgraph-token-refresh (profile: msgraph-secret lub msgraph-cert)
+TENANT_ID=
+CLIENT_ID=
+MSGRAPH_CERT_THUMBPRINT=
+GRAPH_URL=https://graph.microsoft.com
+REFRESH_SECONDS=3300

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.env
+secrets/*
+!secrets/.gitkeep
+logs/*
+!logs/.gitkeep

--- a/MSGRAPH_TOKEN_SETUP.md
+++ b/MSGRAPH_TOKEN_SETUP.md
@@ -1,0 +1,89 @@
+# Konfiguracja tokena MS Graph w parsedmarc-dockerized
+
+Ten dokument opisuje dwa niezależne, poprawne warianty konfiguracji odświeżania tokena OAuth2 dla Microsoft Graph:
+1. `client secret` (sekret aplikacji)
+2. `certificate` (certyfikat aplikacji)
+
+W obu przypadkach token jest zapisywany przez `msgraph-token-refresh` do współdzielonego wolumenu Docker: `/tokens/.token.json`.
+
+## Wymagania wspólne
+1. Upewnij się, że działa zewnętrzny stack Elasticsearch i istnieje sieć `elasticsearch_elastic` (lub ustaw własną w `.env` jako `ELASTIC_NETWORK`).
+2. Skopiuj plik środowiskowy:
+```bash
+cp .env.example .env
+```
+3. Ustaw co najmniej:
+```env
+TENANT_ID=<tenant-id-guid>
+CLIENT_ID=<app-registration-client-id>
+```
+4. W Entra ID dodaj uprawnienia aplikacyjne do Microsoft Graph wymagane przez Twój scenariusz (np. `Mail.Read` / `Mail.ReadWrite`) i wykonaj `Grant admin consent`.
+
+## Przypadek 1: Token po `client secret`
+
+### 1) Utwórz sekret aplikacji w Entra ID
+1. Wejdź w `App registrations` -> Twoja aplikacja -> `Certificates & secrets` -> `New client secret`.
+2. Skopiuj wartość sekretu (tylko raz).
+
+### 2) Zapisz sekret jako Docker secret (plik lokalny)
+```bash
+printf '%s' 'TU_WKLEJ_CLIENT_SECRET' > secrets/msgraph_client_secret.txt
+chmod 600 secrets/msgraph_client_secret.txt
+```
+
+### 3) Uruchom odświeżanie tokena profilem `msgraph-secret`
+```bash
+sudo docker compose --profile msgraph-secret up -d --build msgraph-token-refresh-secret
+```
+
+### 4) Zweryfikuj wygenerowany token
+```bash
+sudo docker compose exec msgraph-token-refresh-secret sh -c 'ls -l /tokens/.token.json && tail -n +1 /tokens/.token.json'
+```
+
+## Przypadek 2: Token po `certificate`
+
+### 1) Przygotuj certyfikat aplikacji
+Wymagane są:
+1. Klucz prywatny w PEM (`secrets/msgraph_client_certificate.pem`)
+2. Certyfikat publiczny w PEM (`secrets/msgraph_client_certificate_public.pem`)
+3. Thumbprint certyfikatu ustawiony w `.env` jako `MSGRAPH_CERT_THUMBPRINT`
+
+Przykład ustawienia uprawnień plików:
+```bash
+chmod 600 secrets/msgraph_client_certificate.pem
+chmod 644 secrets/msgraph_client_certificate_public.pem
+```
+
+### 2) Dodaj certyfikat publiczny do App Registration
+1. Wejdź w `App registrations` -> Twoja aplikacja -> `Certificates & secrets` -> `Certificates`.
+2. Dodaj certyfikat publiczny odpowiadający kluczowi prywatnemu.
+3. Skopiuj thumbprint i ustaw w `.env`:
+```env
+MSGRAPH_CERT_THUMBPRINT=<thumbprint-bez-spacji>
+```
+
+### 3) Uruchom odświeżanie tokena profilem `msgraph-cert`
+```bash
+sudo docker compose --profile msgraph-cert up -d --build msgraph-token-refresh-cert
+```
+
+### 4) Zweryfikuj wygenerowany token
+```bash
+sudo docker compose exec msgraph-token-refresh-cert sh -c 'ls -l /tokens/.token.json && tail -n +1 /tokens/.token.json'
+```
+
+## Integracja z parsedmarc
+`msgraph-token-refresh` generuje token typu bearer w pliku `/tokens/.token.json`.
+To jest przydatne dla integracji, które potrafią czytać gotowy token z pliku.
+W tym repo domyślna konfiguracja `parsedmarc/parsedmarc.ini` używa sekcji `[imap]` i nie korzysta bezpośrednio z tego pliku tokena.
+Jeśli chcesz przejść na natywną konfigurację `[msgraph]` w parsedmarc, skonfiguruj ją osobno zgodnie z dokumentacją parsedmarc i uruchom:
+```bash
+sudo docker compose up -d parsedmarc
+```
+
+## Najczęstsze błędy
+1. `Missing env var: TENANT_ID` lub `CLIENT_ID`: brak wartości w `.env`.
+2. `invalid_client`: błędny sekret, niepasujący certyfikat albo zły `MSGRAPH_CERT_THUMBPRINT`.
+3. Brak pliku `/tokens/.token.json`: nie uruchomiono profilu `msgraph-secret` / `msgraph-cert` albo odświeżacz nie ma poprawnych danych logowania.
+4. `insufficient privileges`: brak wymaganych uprawnień aplikacyjnych w Microsoft Graph albo brak `admin consent`.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Additional docs:
 - [MSGRAPH_TOKEN_SETUP.md](MSGRAPH_TOKEN_SETUP.md) - configuration of MS Graph token refresh using `client secret` and `certificate`
 - [docs/ELK_SETUP_PL.md](docs/ELK_SETUP_PL.md) - uruchomienie i integracja ELK (PL)
 - [docs/ELK_SETUP_EN.md](docs/ELK_SETUP_EN.md) - ELK startup and integration guide (EN)
+- [docs/OPENSEARCH_SETUP_PL.md](docs/OPENSEARCH_SETUP_PL.md) - uruchomienie i integracja OpenSearch (PL)
+- [docs/OPENSEARCH_SETUP_EN.md](docs/OPENSEARCH_SETUP_EN.md) - OpenSearch startup and integration guide (EN)
 
 ## :rocket: Quick Start (MS Graph token refresh)
 1. Prepare env:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This stack includes:
 
 Additional docs:
 - [MSGRAPH_TOKEN_SETUP.md](MSGRAPH_TOKEN_SETUP.md) - configuration of MS Graph token refresh using `client secret` and `certificate`
+- [docs/ELK_SETUP_PL.md](docs/ELK_SETUP_PL.md) - uruchomienie i integracja ELK (PL)
+- [docs/ELK_SETUP_EN.md](docs/ELK_SETUP_EN.md) - ELK startup and integration guide (EN)
 
 ## :rocket: Quick Start (MS Graph token refresh)
 1. Prepare env:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,39 @@ This stack includes:
 - [Elasticsearch & Kibana](https://www.elastic.co/guide/index.html) to store and visualize parsed data
 - [Nginx](https://docs.nginx.com/) to handle basic authorization and SSL offloading
 
+Additional docs:
+- [MSGRAPH_TOKEN_SETUP.md](MSGRAPH_TOKEN_SETUP.md) - configuration of MS Graph token refresh using `client secret` and `certificate`
+
+## :rocket: Quick Start (MS Graph token refresh)
+1. Prepare env:
+```bash
+cp .env.example .env
+```
+2. Fill `.env` (`TENANT_ID`, `CLIENT_ID`; for certificate also `MSGRAPH_CERT_THUMBPRINT`).
+3. Start parsedmarc:
+```bash
+sudo docker compose up -d parsedmarc
+```
+
+### Variant A: client secret
+```bash
+printf '%s' 'TU_WKLEJ_CLIENT_SECRET' > secrets/msgraph_client_secret.txt
+chmod 600 secrets/msgraph_client_secret.txt
+sudo docker compose --profile msgraph-secret up -d --build msgraph-token-refresh-secret
+```
+
+### Variant B: certificate
+```bash
+chmod 600 secrets/msgraph_client_certificate.pem
+chmod 644 secrets/msgraph_client_certificate_public.pem
+sudo docker compose --profile msgraph-cert up -d --build msgraph-token-refresh-cert
+```
+
+Token output file (both variants):
+```bash
+sudo docker compose exec msgraph-token-refresh-secret sh -c 'ls -l /tokens/.token.json && tail -n +1 /tokens/.token.json'
+```
+
 ## :shield: Security note
 Please note that the Fail2Ban technique is not implemented, so posting this project on the Internet :globe_with_meridians: can be risky. 
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Additional docs:
 - [docs/ELK_SETUP_EN.md](docs/ELK_SETUP_EN.md) - ELK startup and integration guide (EN)
 - [docs/OPENSEARCH_SETUP_PL.md](docs/OPENSEARCH_SETUP_PL.md) - uruchomienie i integracja OpenSearch (PL)
 - [docs/OPENSEARCH_SETUP_EN.md](docs/OPENSEARCH_SETUP_EN.md) - OpenSearch startup and integration guide (EN)
+- [docs/HARDENED_RUNTIME_PL.md](docs/HARDENED_RUNTIME_PL.md) - uruchomienie parsedmarc w trybie hardened (PL)
+- [docs/HARDENED_RUNTIME_EN.md](docs/HARDENED_RUNTIME_EN.md) - run parsedmarc in hardened mode (EN)
 
 ## :rocket: Quick Start (MS Graph token refresh)
 1. Prepare env:

--- a/docker-compose-elk.yml
+++ b/docker-compose-elk.yml
@@ -1,0 +1,81 @@
+services:
+  elasticsearch:
+    container_name: elk-elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.4
+    restart: unless-stopped
+    environment:
+      - node.name=es01
+      - cluster.name=parsedmarc
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - xpack.security.enabled=false
+      - xpack.security.enrollment.enabled=false
+      - xpack.security.http.ssl.enabled=false
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - esdata01:/usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:9200 >/dev/null || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 20
+      start_period: 20s
+    networks:
+      - elasticsearch
+
+  kibana:
+    container_name: elk-kibana
+    image: docker.elastic.co/kibana/kibana:8.19.4
+    restart: unless-stopped
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    environment:
+      - SERVER_NAME=parsedmarc
+      - SERVER_HOST=0.0.0.0
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY=change-this-32-char-minimum-key-123
+      - XPACK_REPORTING_ENCRYPTIONKEY=change-this-32-char-minimum-key-456
+      - XPACK_SECURITY_ENCRYPTIONKEY=change-this-32-char-minimum-key-789
+    ports:
+      - "5601:5601"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302' || exit 1"]
+      interval: 20s
+      timeout: 10s
+      retries: 20
+      start_period: 30s
+    networks:
+      - elasticsearch
+
+  nginx:
+    profiles: ["nginx"]
+    container_name: elk-nginx
+    image: nginx:alpine
+    restart: unless-stopped
+    depends_on:
+      kibana:
+        condition: service_healthy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./nginx/ssl:/etc/nginx/ssl:ro
+      - ./nginx/htpasswd:/etc/nginx/htpasswd:ro
+    networks:
+      - elasticsearch
+
+networks:
+  elasticsearch:
+    name: elasticsearch_elastic
+    driver: bridge
+
+volumes:
+  esdata01:

--- a/docker-compose-opensearch.yml
+++ b/docker-compose-opensearch.yml
@@ -1,0 +1,82 @@
+services:
+  opensearch:
+    container_name: opensearch
+    image: opensearchproject/opensearch:2.15.0
+    restart: unless-stopped
+    environment:
+      - node.name=opensearch-node1
+      - cluster.name=parsedmarc-opensearch
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g
+      - DISABLE_INSTALL_DEMO_CONFIG=true
+      - DISABLE_SECURITY_PLUGIN=true
+      - plugins.security.disabled=true
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - opensearch_data:/usr/share/opensearch/data
+    ports:
+      - "9200:9200"
+      - "9600:9600"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:9200 >/dev/null || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 20
+      start_period: 30s
+    networks:
+      elasticsearch:
+        aliases:
+          - es01
+
+  opensearch-dashboards:
+    container_name: opensearch-dashboards
+    image: opensearchproject/opensearch-dashboards:2.15.0
+    restart: unless-stopped
+    depends_on:
+      opensearch:
+        condition: service_healthy
+    environment:
+      OPENSEARCH_HOSTS: '["http://opensearch:9200"]'
+      DISABLE_SECURITY_DASHBOARDS_PLUGIN: "true"
+    ports:
+      - "5601:5601"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -I http://localhost:5601 | grep -q 'HTTP/' || exit 1"]
+      interval: 20s
+      timeout: 10s
+      retries: 20
+      start_period: 40s
+    networks:
+      elasticsearch:
+        aliases:
+          - kibana
+
+  nginx:
+    profiles: ["nginx"]
+    container_name: opensearch-nginx
+    image: nginx:alpine
+    restart: unless-stopped
+    depends_on:
+      opensearch-dashboards:
+        condition: service_healthy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./nginx/ssl:/etc/nginx/ssl:ro
+      - ./nginx/htpasswd:/etc/nginx/htpasswd:ro
+    networks:
+      - elasticsearch
+
+networks:
+  elasticsearch:
+    name: elasticsearch_elastic
+    driver: bridge
+
+volumes:
+  opensearch_data:

--- a/docker-compose.hardened.yml
+++ b/docker-compose.hardened.yml
@@ -1,0 +1,18 @@
+services:
+  parsedmarc:
+    build:
+      context: ./parsedmarc
+      dockerfile: Dockerfile.hardened
+      args:
+        PARSEDMARC_VERSION: ${PARSEDMARC_VERSION:-9.1.0}
+    image: parsedmarc:hardened
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=64m
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    pids_limit: 256
+    mem_limit: 512m
+    cpus: 1.0

--- a/docker-compose.hardened.yml
+++ b/docker-compose.hardened.yml
@@ -4,7 +4,7 @@ services:
       context: ./parsedmarc
       dockerfile: Dockerfile.hardened
       args:
-        PARSEDMARC_VERSION: ${PARSEDMARC_VERSION:-9.1.0}
+        PARSEDMARC_VERSION: ${PARSEDMARC_VERSION:-9.2.0}
     image: parsedmarc:hardened
     read_only: true
     tmpfs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,75 +1,76 @@
-version: '3.4'
-
 services:
   parsedmarc:
-    container_name: "parsedmarc"
+    container_name: parsedmarc
+    image: ghcr.io/mkilijanek/parsedmarc:latest
+    restart: unless-stopped
+    command: ["-c", "/etc/parsedmarc.ini"]
+    volumes:
+      - ./parsedmarc/parsedmarc.ini:/etc/parsedmarc.ini:ro
+      - ./logs:/var/log/parsedmarc
+      - msgraph_tokens:/tokens:ro
+    networks:
+      - elasticsearch
+
+  msgraph-token-refresh-secret:
+    profiles: ["msgraph-secret"]
     build:
-      context: .
-      dockerfile: parsedmarc/Dockerfile
-    command: "parsedmarc -c /etc/parsedmarc.ini"
-    tty: true
-    volumes:
-      - ./parsedmarc/parsedmarc.ini:/etc/parsedmarc.ini:z
-      #- /path/to/GeoIP:/usr/share/GeoIP
+      context: ./msgraph-token-refresh
+    container_name: msgraph-token-refresh-secret
     restart: unless-stopped
-    networks:
-      - parsedmarc-network
-    depends_on:
-      - elasticsearch
-
-  elasticsearch:
-    container_name: "elasticsearch"
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
     environment:
-      - cluster.name=parsedmarc
-      - discovery.type=single-node
-      - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
+      AUTH_METHOD: client_secret
+      TENANT_ID: ${TENANT_ID:-}
+      CLIENT_ID: ${CLIENT_ID:-}
+      GRAPH_URL: ${GRAPH_URL:-https://graph.microsoft.com}
+      TOKEN_PATH: /tokens/.token.json
+      REFRESH_SECONDS: ${REFRESH_SECONDS:-3300}
     volumes:
-      - ./elasticsearch/data/:/usr/share/elasticsearch/data/:z
-    restart: "unless-stopped"
-    networks:
-      - parsedmarc-network
+      - msgraph_tokens:/tokens
+    secrets:
+      - msgraph_client_secret
     healthcheck:
-      test: ["CMD", "curl","-s" ,"-f", "http://localhost:9200/_cat/health"]
-      interval: 1m
-      timeout: 10s
-      retries: 3
-      start_period: 30s
+      test: ["CMD-SHELL", "test -s /tokens/.token.json"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
 
-  kibana:
-    container_name: "kibana"
-    image: docker.elastic.co/kibana/kibana:7.17.0
+  msgraph-token-refresh-cert:
+    profiles: ["msgraph-cert"]
+    build:
+      context: ./msgraph-token-refresh
+    container_name: msgraph-token-refresh-cert
+    restart: unless-stopped
     environment:
-      SERVER_NAME: parsedmarc
-      SERVER_HOST: "0.0.0.0"
-      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
-      XPACK_MONITORING_UI_CONTAINER_ELASTICSEARCH_ENABLED: "true"
-    restart: unless-stopped
-    networks:
-      - parsedmarc-network
-    depends_on:
-      - elasticsearch
-
-  nginx:
-    container_name: "nginx"
-    image: nginx:alpine
-    restart: unless-stopped
-    tty: true
-    ports:
-      - "80:80"
-      - "443:443"
+      AUTH_METHOD: certificate
+      TENANT_ID: ${TENANT_ID:-}
+      CLIENT_ID: ${CLIENT_ID:-}
+      MSGRAPH_CERT_THUMBPRINT: ${MSGRAPH_CERT_THUMBPRINT:-}
+      GRAPH_URL: ${GRAPH_URL:-https://graph.microsoft.com}
+      TOKEN_PATH: /tokens/.token.json
+      REFRESH_SECONDS: ${REFRESH_SECONDS:-3300}
     volumes:
-      - ./nginx/conf.d/:/etc/nginx/conf.d/:z
-      - ./nginx/ssl/:/etc/nginx/ssl/:z
-      - ./nginx/htpasswd:/etc/nginx/htpasswd:z
-    networks:
-      - parsedmarc-network
+      - msgraph_tokens:/tokens
+    secrets:
+      - msgraph_client_certificate_pem
+      - msgraph_client_certificate_public_pem
+    healthcheck:
+      test: ["CMD-SHELL", "test -s /tokens/.token.json"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
 
 networks:
-    parsedmarc-network:
-      driver: bridge
+  elasticsearch:
+    external: true
+    name: ${ELASTIC_NETWORK:-elasticsearch_elastic}
+
+secrets:
+  msgraph_client_secret:
+    file: ./secrets/msgraph_client_secret.txt
+  msgraph_client_certificate_pem:
+    file: ./secrets/msgraph_client_certificate.pem
+  msgraph_client_certificate_public_pem:
+    file: ./secrets/msgraph_client_certificate_public.pem
+
+volumes:
+  msgraph_tokens:

--- a/docs/ELK_SETUP_EN.md
+++ b/docs/ELK_SETUP_EN.md
@@ -1,0 +1,51 @@
+# ELK Setup (EN)
+
+This document describes how to run the local ELK stack from `docker-compose-elk.yml`.
+The stack creates the `elasticsearch_elastic` Docker network used by `parsedmarc` from the main `docker-compose.yml`.
+
+## What `docker-compose-elk.yml` starts
+- `elasticsearch` (single-node, port `9200`)
+- `kibana` (port `5601`)
+- optional `nginx` (profile `nginx`, ports `80` and `443`)
+
+## Start ELK
+```bash
+sudo docker compose -f docker-compose-elk.yml up -d
+```
+
+## Start ELK + Nginx
+```bash
+sudo docker compose -f docker-compose-elk.yml --profile nginx up -d
+```
+
+## Check status
+```bash
+sudo docker compose -f docker-compose-elk.yml ps
+sudo docker compose -f docker-compose-elk.yml logs -f elasticsearch kibana
+```
+
+## Integration with parsedmarc
+After ELK is up, start parser separately:
+```bash
+sudo docker compose up -d parsedmarc
+```
+
+In `parsedmarc/parsedmarc.ini`, Elasticsearch host should point to the container in that network, e.g.:
+```ini
+[elasticsearch]
+hosts = es01:9200
+ssl = False
+```
+
+Note: if you use TLS/secured Elasticsearch, adjust `hosts`, `ssl`, `user`, and `password` for your environment.
+
+## Stop
+```bash
+sudo docker compose -f docker-compose-elk.yml down
+```
+
+## Remove Elasticsearch data
+```bash
+sudo docker compose -f docker-compose-elk.yml down -v
+```
+This removes the `esdata01` volume.

--- a/docs/ELK_SETUP_PL.md
+++ b/docs/ELK_SETUP_PL.md
@@ -1,0 +1,51 @@
+# Konfiguracja ELK (PL)
+
+Ten dokument opisuje uruchomienie lokalnego stacka ELK z pliku `docker-compose-elk.yml`.
+Stack tworzy sieć `elasticsearch_elastic`, do której podłącza się `parsedmarc` z głównego `docker-compose.yml`.
+
+## Co uruchamia `docker-compose-elk.yml`
+- `elasticsearch` (single-node, port `9200`)
+- `kibana` (port `5601`)
+- opcjonalnie `nginx` (profil `nginx`, porty `80` i `443`)
+
+## Start ELK
+```bash
+sudo docker compose -f docker-compose-elk.yml up -d
+```
+
+## Start ELK + Nginx
+```bash
+sudo docker compose -f docker-compose-elk.yml --profile nginx up -d
+```
+
+## Sprawdzenie stanu
+```bash
+sudo docker compose -f docker-compose-elk.yml ps
+sudo docker compose -f docker-compose-elk.yml logs -f elasticsearch kibana
+```
+
+## Integracja z parsedmarc
+Po uruchomieniu ELK uruchom parser osobno:
+```bash
+sudo docker compose up -d parsedmarc
+```
+
+W `parsedmarc/parsedmarc.ini` host Elasticsearch powinien wskazywać kontener z tej sieci, np.:
+```ini
+[elasticsearch]
+hosts = es01:9200
+ssl = False
+```
+
+Uwaga: jeśli używasz wersji TLS/secured Elasticsearch, dostosuj `hosts`, `ssl`, `user`, `password` do swojego środowiska.
+
+## Zatrzymanie
+```bash
+sudo docker compose -f docker-compose-elk.yml down
+```
+
+## Usunięcie danych Elasticsearch
+```bash
+sudo docker compose -f docker-compose-elk.yml down -v
+```
+To usunie wolumen `esdata01`.

--- a/docs/HARDENED_RUNTIME_EN.md
+++ b/docs/HARDENED_RUNTIME_EN.md
@@ -1,0 +1,28 @@
+# Parsedmarc Hardening (EN)
+
+This document describes how to run `parsedmarc` in a hardened mode without changing the main `docker-compose.yml`.
+
+## What `docker-compose.hardened.yml` does
+It overrides only the `parsedmarc` service:
+- build from `parsedmarc/Dockerfile.hardened` (distroless runtime)
+- read-only root filesystem (`read_only: true`)
+- `tmpfs` for `/tmp`
+- `no-new-privileges`
+- `cap_drop: ALL`
+- resource limits (`pids_limit`, `mem_limit`, `cpus`)
+
+## Start
+```bash
+sudo docker compose -f docker-compose.yml -f docker-compose.hardened.yml up -d --build parsedmarc
+```
+
+## Verify
+```bash
+sudo docker compose -f docker-compose.yml -f docker-compose.hardened.yml ps
+sudo docker compose -f docker-compose.yml -f docker-compose.hardened.yml logs -f parsedmarc
+```
+
+## Roll back to standard image
+```bash
+sudo docker compose -f docker-compose.yml up -d parsedmarc
+```

--- a/docs/HARDENED_RUNTIME_PL.md
+++ b/docs/HARDENED_RUNTIME_PL.md
@@ -1,0 +1,28 @@
+# Parsedmarc Hardening (PL)
+
+Ten dokument opisuje uruchomienie `parsedmarc` w wariancie utwardzonym (hardened), bez zmiany głównego `docker-compose.yml`.
+
+## Co daje `docker-compose.hardened.yml`
+Plik nadpisuje tylko usługę `parsedmarc`:
+- build z `parsedmarc/Dockerfile.hardened` (distroless runtime)
+- root filesystem tylko do odczytu (`read_only: true`)
+- `tmpfs` dla `/tmp`
+- `no-new-privileges`
+- `cap_drop: ALL`
+- limity zasobów (`pids_limit`, `mem_limit`, `cpus`)
+
+## Uruchomienie
+```bash
+sudo docker compose -f docker-compose.yml -f docker-compose.hardened.yml up -d --build parsedmarc
+```
+
+## Weryfikacja
+```bash
+sudo docker compose -f docker-compose.yml -f docker-compose.hardened.yml ps
+sudo docker compose -f docker-compose.yml -f docker-compose.hardened.yml logs -f parsedmarc
+```
+
+## Powrót do standardowego obrazu
+```bash
+sudo docker compose -f docker-compose.yml up -d parsedmarc
+```

--- a/docs/OPENSEARCH_SETUP_EN.md
+++ b/docs/OPENSEARCH_SETUP_EN.md
@@ -1,0 +1,51 @@
+# OpenSearch Setup (EN)
+
+This document describes how to run the local OpenSearch stack from `docker-compose-opensearch.yml`.
+The stack creates the `elasticsearch_elastic` Docker network used by `parsedmarc` from the main `docker-compose.yml`.
+
+## What `docker-compose-opensearch.yml` starts
+- `opensearch` (ports `9200` and `9600`)
+- `opensearch-dashboards` (port `5601`)
+- optional `nginx` (profile `nginx`, ports `80` and `443`)
+
+## Start OpenSearch
+```bash
+sudo docker compose -f docker-compose-opensearch.yml up -d
+```
+
+## Start OpenSearch + Nginx
+```bash
+sudo docker compose -f docker-compose-opensearch.yml --profile nginx up -d
+```
+
+## Check status
+```bash
+sudo docker compose -f docker-compose-opensearch.yml ps
+sudo docker compose -f docker-compose-opensearch.yml logs -f opensearch opensearch-dashboards
+```
+
+## Integration with parsedmarc
+After OpenSearch is up, start parser separately:
+```bash
+sudo docker compose up -d parsedmarc
+```
+
+In `parsedmarc/parsedmarc.ini`, the search backend host should point to a service in that network, for example:
+```ini
+[elasticsearch]
+hosts = es01:9200
+ssl = False
+```
+
+Note: `es01` alias is configured on the `opensearch` service, so existing parsedmarc settings can stay unchanged.
+
+## Stop
+```bash
+sudo docker compose -f docker-compose-opensearch.yml down
+```
+
+## Remove OpenSearch data
+```bash
+sudo docker compose -f docker-compose-opensearch.yml down -v
+```
+This removes the `opensearch_data` volume.

--- a/docs/OPENSEARCH_SETUP_PL.md
+++ b/docs/OPENSEARCH_SETUP_PL.md
@@ -1,0 +1,51 @@
+# Konfiguracja OpenSearch (PL)
+
+Ten dokument opisuje uruchomienie lokalnego stacka OpenSearch z pliku `docker-compose-opensearch.yml`.
+Stack tworzy sieć `elasticsearch_elastic`, do której podłącza się `parsedmarc` z głównego `docker-compose.yml`.
+
+## Co uruchamia `docker-compose-opensearch.yml`
+- `opensearch` (porty `9200` i `9600`)
+- `opensearch-dashboards` (port `5601`)
+- opcjonalnie `nginx` (profil `nginx`, porty `80` i `443`)
+
+## Start OpenSearch
+```bash
+sudo docker compose -f docker-compose-opensearch.yml up -d
+```
+
+## Start OpenSearch + Nginx
+```bash
+sudo docker compose -f docker-compose-opensearch.yml --profile nginx up -d
+```
+
+## Sprawdzenie stanu
+```bash
+sudo docker compose -f docker-compose-opensearch.yml ps
+sudo docker compose -f docker-compose-opensearch.yml logs -f opensearch opensearch-dashboards
+```
+
+## Integracja z parsedmarc
+Po uruchomieniu OpenSearch uruchom parser osobno:
+```bash
+sudo docker compose up -d parsedmarc
+```
+
+W `parsedmarc/parsedmarc.ini` host wyszukiwarki powinien wskazywać usługę w tej samej sieci, np.:
+```ini
+[elasticsearch]
+hosts = es01:9200
+ssl = False
+```
+
+Uwaga: alias `es01` jest zdefiniowany na usłudze `opensearch`, więc obecna konfiguracja `parsedmarc` może pozostać bez zmian.
+
+## Zatrzymanie
+```bash
+sudo docker compose -f docker-compose-opensearch.yml down
+```
+
+## Usunięcie danych OpenSearch
+```bash
+sudo docker compose -f docker-compose-opensearch.yml down -v
+```
+To usunie wolumen `opensearch_data`.

--- a/parsedmarc/Dockerfile
+++ b/parsedmarc/Dockerfile
@@ -1,9 +1,27 @@
-FROM docker.io/library/pypy:latest
+FROM python:3-alpine3.23
 
-RUN apt-get update \
-    && apt-get install -y libxml2-dev libxslt-dev python3-dev \
-    && pip install --no-cache-dir parsedmarc \
-    && rm -rf /root/.cache/ \
-    && rm -rf /var/lib/{apt,dpkg}/
+ARG PARSEDMARC_VERSION=9.2.0
+ARG VCS_REF=""
+ARG BUILD_DATE=""
+ARG SOURCE_DATE_EPOCH=""
 
-CMD ["parsedmarc"]
+ENV PARSEDMARC_VERSION=${PARSEDMARC_VERSION}
+
+LABEL org.opencontainers.image.source="https://github.com/mkilijanek/parsedmarc" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.version="${PARSEDMARC_VERSION}" \
+      org.opencontainers.image.vendor="mkilijanek" \
+      org.opencontainers.image.title="parsedmarc (containerized)"
+
+RUN python -m pip install --no-cache-dir --upgrade pip \
+ && pip install --no-cache-dir "parsedmarc==${PARSEDMARC_VERSION}" \
+ && adduser -D -h /home/parsedmarc -u 1000 parsedmarc \
+ && mkdir -p /home/parsedmarc/ini /var/log/parsedmarc \
+ && chown -R 1000:1000 /home/parsedmarc /var/log/parsedmarc
+
+USER parsedmarc
+WORKDIR /home/parsedmarc
+
+ENTRYPOINT ["parsedmarc"]
+CMD ["-h"]

--- a/parsedmarc/Dockerfile.hardened
+++ b/parsedmarc/Dockerfile.hardened
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+
+############################
+# Builder stage
+############################
+FROM python:3.12-slim AS builder
+
+ARG PARSEDMARC_VERSION=9.2.0
+ARG VCS_REF=""
+ARG BUILD_DATE=""
+ARG SOURCE_DATE_EPOCH=""
+
+ENV VENV_PATH=/opt/venv
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+RUN python -m venv "${VENV_PATH}" \
+ && "${VENV_PATH}/bin/pip" install --no-cache-dir --upgrade pip \
+ && "${VENV_PATH}/bin/pip" install --no-cache-dir "parsedmarc==${PARSEDMARC_VERSION}"
+
+############################
+# Runtime stage (distroless)
+############################
+FROM gcr.io/distroless/python3-debian12:nonroot
+
+ARG PARSEDMARC_VERSION=9.2.0
+ARG VCS_REF=""
+ARG BUILD_DATE=""
+ARG SOURCE_DATE_EPOCH=""
+
+LABEL org.opencontainers.image.source="https://github.com/mkilijanek/parsedmarc" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.version="${PARSEDMARC_VERSION}" \
+      org.opencontainers.image.vendor="mkilijanek" \
+      org.opencontainers.image.title="parsedmarc (distroless)"
+
+ENV VENV_PATH=/opt/venv
+ENV PATH="${VENV_PATH}/bin:${PATH}"
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+COPY --from=builder ${VENV_PATH} ${VENV_PATH}
+
+USER 65532:65532
+
+ENTRYPOINT ["parsedmarc"]
+CMD ["-h"]

--- a/parsedmarc/build.sh
+++ b/parsedmarc/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+PARSEDMARC_VERSION=${PARSEDMARC_VERSION:-9.2.0}
+IMAGE_TAG=${IMAGE_TAG:-$PARSEDMARC_VERSION}
+IMAGE_NAME=${IMAGE_NAME:-ghcr.io/mkilijanek/parsedmarc}
+
+docker build \
+  --build-arg PARSEDMARC_VERSION=${PARSEDMARC_VERSION} \
+  --build-arg VCS_REF=$(git rev-parse --short HEAD) \
+  --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+  -t ${IMAGE_NAME}:${IMAGE_TAG} .
+
+if [ -n "$GHCR_TOKEN" ]; then
+  echo "$GHCR_TOKEN" | docker login ghcr.io -u "${GITHUB_USER}" --password-stdin
+  docker push ${IMAGE_NAME}:${IMAGE_TAG}
+fi

--- a/parsedmarc/parsedmarc.ini
+++ b/parsedmarc/parsedmarc.ini
@@ -1,13 +1,26 @@
 [general]
 save_aggregate = True
 save_forensic = True
+n_procs = 4
+chunk_size = 256
+log_file = /var/log/parsedmarc/parsedmarc.log
+debug = False
 
 [imap]
 host = imap.example.com
+port = 993
 user = parsedmarc@example.com
-password = somepassword
+password = change_me
+ssl = True
+
+[mailbox]
 watch = True
+batch_size = 10
+reports_folder = DMARC
+archive_folder = DMARC_Archived
 
 [elasticsearch]
-hosts = http://elasticsearch:9200
-ssl = False
+hosts = es01:9200
+user = elastic
+password = change_me
+ssl = True

--- a/parsedmarc/parsedmarc.ini
+++ b/parsedmarc/parsedmarc.ini
@@ -1,26 +1,167 @@
+# parsedmarc configuration template (based on docs: https://domainaware.github.io/parsedmarc/usage.html#configuration-file)
+
 [general]
 save_aggregate = True
 save_forensic = True
-n_procs = 4
-chunk_size = 256
-log_file = /var/log/parsedmarc/parsedmarc.log
+save_smtp_tls = False
+# index_prefix_domain_map = /etc/parsedmarc/tenant_domain_map.yml
+strip_attachment_payloads = False
+silent = True
+# output = /tmp/parsedmarc-output
+# aggregate_json_filename = aggregate.json
+# forensic_json_filename = forensic.json
+# smtp_tls_json_filename = smtp_tls.json
+# aggregate_csv_filename = aggregate.csv
+# forensic_csv_filename = forensic.csv
+# smtp_tls_csv_filename = smtp_tls.csv
+# ip_db_path = /usr/share/GeoIP/GeoLite2-City.mmdb
+offline = False
+always_use_local_files = False
+# local_reverse_dns_map_path = /opt/parsedmarc/base_reverse_dns_map.csv
+# reverse_dns_map_url = https://raw.githubusercontent.com/domainaware/parsedmarc/master/parsedmarc/resources/maps/base_reverse_dns_map.csv
+# nameservers = 1.1.1.1,1.0.0.1
+# dns_test_address = 1.1.1.1
+dns_timeout = 2.0
 debug = False
+log_file = /var/log/parsedmarc/parsedmarc.log
+n_procs = 4
+
+[mailbox]
+reports_folder = DMARC
+archive_folder = DMARC_Archived
+watch = True
+delete = False
+test = False
+batch_size = 10
+check_timeout = 30
+# since = 1d
 
 [imap]
 host = imap.example.com
 port = 993
+ssl = True
+skip_certificate_verification = False
 user = parsedmarc@example.com
 password = change_me
-ssl = True
 
-[mailbox]
-watch = True
-batch_size = 10
-reports_folder = DMARC
-archive_folder = DMARC_Archived
+[msgraph]
+# auth_method = UsernamePassword
+# user = user@example.com
+# password = change_me
+# client_id = 00000000-0000-0000-0000-000000000000
+# client_secret = change_me
+# tenant_id = 00000000-0000-0000-0000-000000000000
+# mailbox = reports@example.com
+# graph_url = https://graph.microsoft.com
+# token_file = /tokens/.token.json
+# allow_unencrypted_storage = False
 
 [elasticsearch]
 hosts = es01:9200
 user = elastic
 password = change_me
+# api_key =
 ssl = True
+timeout = 60
+# cert_path = /etc/ssl/certs/ca-certificates.crt
+# index_suffix =
+# index_prefix =
+monthly_indexes = False
+number_of_shards = 1
+number_of_replicas = 0
+
+[opensearch]
+# hosts = es01:9200
+# user = admin
+# password = change_me
+# api_key =
+# ssl = True
+# timeout = 60
+# cert_path = /etc/ssl/certs/ca-certificates.crt
+# index_suffix =
+# index_prefix =
+# monthly_indexes = False
+# number_of_shards = 1
+# number_of_replicas = 0
+
+[splunk_hec]
+# url = https://splunkhec.example.com
+# token = HECTokenGoesHere
+# index = email
+# skip_certificate_verification = False
+
+[kafka]
+# hosts = kafka1:9092,kafka2:9092
+# user =
+# password =
+# NOTE: Documentation currently shows `passsword` (with 3x "s").
+# passsword =
+# ssl = True
+# skip_certificate_verification = False
+# aggregate_topic = parsedmarc_aggregate
+# forensic_topic = parsedmarc_forensic
+
+[smtp]
+# host = smtp.example.com
+# port = 25
+# ssl = False
+# skip_certificate_verification = False
+# user =
+# password =
+# from = parsedmarc@example.com
+# to = secops@example.com,postmaster@example.com
+# subject = parsedmarc report
+# attachment = aggregate,forensic,smtp_tls
+# message = Please see the attached parsedmarc report.
+
+[s3]
+# bucket = my-bucket
+# path = parsedmarc
+# region_name = eu-central-1
+# endpoint_url =
+# access_key_id =
+# secret_access_key =
+
+[syslog]
+# server = localhost
+# port = 514
+# protocol = udp
+# cafile_path =
+# certfile_path =
+# keyfile_path =
+# timeout = 5.0
+# retry_attempts = 3
+# retry_delay = 5
+
+[gmail_api]
+# credentials_file = /etc/parsedmarc/gmail-credentials.json
+# token_file = /etc/parsedmarc/gmail-token.json
+# include_spam_trash = False
+# scopes = https://www.googleapis.com/auth/gmail.modify
+# oauth2_port = 8080
+# paginate_messages = True
+
+[log_analytics]
+# client_id = 00000000-0000-0000-0000-000000000000
+# client_secret = change_me
+# tenant_id = 00000000-0000-0000-0000-000000000000
+# dce = https://<dce-name>.<region>.ingest.monitor.azure.com
+# dcr_immutable_id =
+# dcr_aggregate_stream =
+# dcr_forensic_stream =
+# dcr_smtp_tls_stream =
+
+[gelf]
+# host = logger
+# port = 12201
+# mode = tcp
+
+[maildir]
+# maildir_path = INBOX
+# maildir_create = False
+
+[webhook]
+# aggregate_url = https://aggregate-url.example.com
+# forensic_url = https://forensic-url.example.com
+# smtp_tls_url = https://smtp-tls-url.example.com
+# timeout = 60

--- a/parsedmarc/requirements.in
+++ b/parsedmarc/requirements.in
@@ -1,0 +1,2 @@
+parsedmarc==9.2.0
+urllib3>=2.6.0


### PR DESCRIPTION
## Summary

This PR improves the Dockerized deployment of parsedmarc by introducing a more production-ready runtime and support for Microsoft Graph token refresh.

The goal is to make the stack easier to operate in modern environments (especially Microsoft 365) while keeping the default workflow simple.

## Key Changes

### 1. Docker Compose Improvements
- Use prebuilt image (`ghcr.io/mkilijanek/parsedmarc:latest`) instead of building locally.
- Add `restart: unless-stopped`.
- Mount configuration in read-only mode.
- Add dedicated log directory.
- Add shared token volume for MS Graph authentication.

### 2. Microsoft Graph Token Refresh

Added an optional container for refreshing Microsoft Graph access tokens:

- Supports **client secret** and **certificate authentication**.
- Stores refreshed tokens in a shared volume.
- Allows parsedmarc to access Microsoft 365 mailboxes without storing long-lived credentials.

Profiles:
```
--profile msgraph-secret
--profile msgraph-cert
```

### 3. Expanded parsedmarc Configuration Template

`parsedmarc.ini` now contains a more complete template including:

- logging configuration
- DNS tuning
- multiprocessing
- mailbox settings
- optional MS Graph configuration

This helps new deployments avoid common configuration pitfalls.

### 4. Additional Deployment Options

Added compose variants for different environments:

- `docker-compose-opensearch.yml`
- `docker-compose-elk.yml`
- `docker-compose.hardened.yml`

These provide ready-to-use stacks for:

- OpenSearch deployments
- Elasticsearch/Kibana deployments
- hardened container runtime setups

### 5. Documentation

Added additional documentation:

- ELK setup guide (EN / PL)
- OpenSearch setup guide (EN / PL)
- Hardened runtime guide
- Microsoft Graph token refresh configuration

### 6. Environment Template

Added `.env.example` to simplify environment configuration.

## Compatibility

The default behavior remains unchanged for users who only run:
```
docker compose up -d parsedmarc
```

Additional features are opt-in via compose profiles.

## Motivation

Many parsedmarc deployments now rely on Microsoft 365 mailboxes and modern containerized infrastructure. This PR aims to:

- simplify MS Graph authentication
- improve container security
- provide production-ready examples
- support both OpenSearch and Elasticsearch backends

## Testing

Tested with:

- Docker Compose v2
- parsedmarc latest image
- Microsoft Graph mailbox access
- OpenSearch and Elasticsearch backends

## Feedback welcome
Happy to split this PR if maintainers prefer smaller changes.

